### PR TITLE
move 'env2' to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "devDependencies": {
     "decache": "^3.0.3",
-    "env2": "^2.0.7",
     "istanbul": "^0.4.0",
     "jshint": "^2.8.0",
     "pre-commit": "1.1.2",
@@ -50,6 +49,7 @@
   ],
   "dependencies": {
     "aws-sdk": "^2.3.7",
+    "env2": "^2.0.7",
     "handlebars": "^4.0.3"
   }
 }


### PR DESCRIPTION
gets installed together with sendemail (no crash when requiring env2)

related #51