### PR TITLE
Allowing for stubbable api

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ If you are stuck, have a look at **/examples/templates/**
 Create a file called `email.js` and paste the following:
 
 ```js
-var email   = require('sendemail'); // no api key
-email.set_template_directory('./relative/path/to/template/directory');
+var sendemail   = require('sendemail').email; // no api key
+var email = sendemail.email;
+sendemail.set_template_directory('./relative/path/to/template/directory');
 
 var person = {
   name : "Jenny",

--- a/examples/send-welcome-email.js
+++ b/examples/send-welcome-email.js
@@ -3,11 +3,12 @@ var path    = require('path'); // used to resolve relative paths
 var config  = path.resolve(__dirname+'/../config.env'); // load config file
 var env     = require('env2')(config);
 
-var email   = require('../lib/index.js'); // no api key
+var sendemail = require('../lib/index.js'); // no api key
+var email     = sendemail.email;
 
 var dir = __dirname + '/../examples/templates'; // unresolved
 dir = path.resolve(dir);
-email.set_template_directory(dir); // set template directory
+sendemail.set_template_directory(dir); // set template directory
 
 var person = {
   name : "Jenny",

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 require('env2')('.env');
-var AWS     = require('aws-sdk');
+var AWS = require('aws-sdk');
 AWS.config.region = process.env.AWS_REGION;
 var ses = new AWS.SES();
 var path               = require('path');       // resolve template files
@@ -48,7 +48,7 @@ function compile_template(template_name, type) {
  * @param {Function} callback - continuation function called after
  * the email has been sent.
  */
-module.exports = function sendemail(template_name, person, callback) {
+function sendemail(template_name, person, callback) {
   // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
   var params = {
     Destination: { /* required */
@@ -84,5 +84,6 @@ module.exports = function sendemail(template_name, person, callback) {
 
 };
 
+module.exports.email = sendemail;
 module.exports.compile_template = compile_template;
 module.exports.set_template_directory = set_template_directory;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,10 @@
-var email   = require('../lib/index.js'); // auto-set TEMPLATE_DIR
-var path    = require('path');
-var test    = require('tape');
-var dir     = __dirname.split('/')[__dirname.split('/').length-1];
-var file    = dir + __filename.replace(__dirname, '');
-var decache = require('decache');
+var sendemail = require('../lib/index.js'); // auto-set TEMPLATE_DIR
+var email     = sendemail.email;
+var path      = require('path');
+var test      = require('tape');
+var dir       = __dirname.split('/')[__dirname.split('/').length-1];
+var file      = dir + __filename.replace(__dirname, '');
+var decache   = require('decache');
 
 var TEMPLATE_DIR = process.env.TEMPLATE_DIRECTORY; // copy
 delete process.env.TEMPLATE_DIRECTORY;             // delete
@@ -15,7 +16,7 @@ test(file+" process.env.TEMPLATE_DIRECTORY has been unset", function(t) {
 
 test(file+" set_template_directory without args throws error!", function(t) {
   try {
-    email.set_template_directory();
+    sendemail.set_template_directory();
   } catch (e) {
     t.ok(e.indexOf('Please Set a Template Directory') > -1, 'Error Thrown: '+e)
     t.equal(process.env.TEMPLATE_DIRECTORY, undefined, "Not Set (as expected)");
@@ -25,7 +26,7 @@ test(file+" set_template_directory without args throws error!", function(t) {
 
 test(file+" set_template_directory with INVALID directory!", function(t) {
   try {
-    email.set_template_directory('/invalid');
+    sendemail.set_template_directory('/invalid');
   } catch (e) {
     console.log(e.code);
     t.ok(e.code === 'ENOENT', 'FS Error: '+JSON.stringify(e))
@@ -38,7 +39,7 @@ test(file+" attempt to compile non-existent template (fail!)", function(t) {
   try {
     process.env.TEMPLATE_DIRECTORY = TEMPLATE_DIR;
     console.log('TEMPLATE_DIR:', TEMPLATE_DIR);
-    email.compile_template('no-file.html');
+    sendemail.compile_template('no-file.html');
   } catch (e) {
     t.ok(e.code === 'ENOENT', 'FS Error: '+JSON.stringify(e))
     t.end();
@@ -48,21 +49,21 @@ test(file+" attempt to compile non-existent template (fail!)", function(t) {
 var Handlebars = require('handlebars');
 
 test(file+" compile a known template", function(t) {
-  var c = email.compile_template('hello', 'html');
+  var c = sendemail.compile_template('hello', 'html');
   var result = c({name:'Jimmy'});
   t.ok(result.indexOf("<p>Hello Jimmy!</p>") > -1, 'Rendered: '+result);
   t.end()
 });
 
 test(file+" compile .html template from cache", function(t) {
-  var c = email.compile_template('hello', 'html');
+  var c = sendemail.compile_template('hello', 'html');
   var result = c({name:'Jenny'});
   t.ok(result.indexOf("<p>Hello Jenny!</p>") > -1, 'Rendered: '+result);
   t.end()
 });
 
 test(file+" compile .txt template", function(t) {
-  var c = email.compile_template('hello', 'txt');
+  var c = sendemail.compile_template('hello', 'txt');
   var result = c({name:'Jenny'});
   t.ok(result.indexOf("Hello Jenny!") > -1, 'Rendered: '+result);
   t.end()


### PR DESCRIPTION
This pr alters the api so that `email` is a method on the `require(sendemail)` object.
This makes it possible to stub.

Fixes #55 

@nelsonic 
This syntax:
```
var email = require('sendemail').email
```

Made it awkward to reference the other methods of `sendemail`.
The pr now provides a stubbable interface, but accessing the other methods isn't that nice, I'm absolutely fine with redoing it another way or this may just be good to go.

Let me know your thoughts