### PR TITLE
no longer forcing a user to use env2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-require('env2')('.env');
 var AWS = require('aws-sdk');
 AWS.config.region = process.env.AWS_REGION;
 var ses = new AWS.SES();
@@ -82,7 +81,7 @@ function sendemail(template_name, person, callback) {
     return callback(err, data);
   });
 
-};
+}
 
 module.exports.email = sendemail;
 module.exports.compile_template = compile_template;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "decache": "^4.1.0",
+    "env2": "^2.0.7",
     "istanbul": "^0.4.0",
     "jshint": "^2.8.0",
     "pre-commit": "1.1.2",
@@ -49,7 +50,6 @@
   ],
   "dependencies": {
     "aws-sdk": "^2.3.7",
-    "env2": "^2.0.7",
     "handlebars": "^4.0.3"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,4 @@
+require('env2')('.env');
 var sendemail = require('../lib/index.js'); // auto-set TEMPLATE_DIR
 var email     = sendemail.email;
 var path      = require('path');


### PR DESCRIPTION
Fixes #44 

 - Making env2 a dev dependency
 - No longer requiring 'env2' in `index.js`
 - Requiring it in `test.js` instead