### PR TITLE
Allows to send email using AWS SES in To, CC & BCC fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,17 @@
+var proxy = require('proxy-agent');
+var myproxy = process.env.HTTP_PROXY;
 var AWS = require('aws-sdk');
 AWS.config.region = process.env.AWS_REGION;
+AWS.config.update({
+    httpOptions: { agent: proxy(myproxy) }
+});
 var ses = new AWS.SES();
 var path = require('path'); // resolve template files
 var fs = require('fs'); // open tempalte files
 var Handlebars = require('handlebars'); // compile templates
 var COMPILED_TEMPLATES = {}; // cache compiled templates
+
+
 
 /**
  * set_template_directory does exactly what its name suggests
@@ -103,46 +110,52 @@ function sendemail(template_name, person, callback) {
 function sendemails(template_name, subject, personTO, personCC, personBCC, callback) {
     // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
 
-
-    var toEmailAddress = ''
-
-    for (var l = 0; l < personTO.length; l++) {
-        toEmailAddress = toEmailAddress + personTO[l].email + ","
+    var toEmailAddress = [];
+    if (personTO === null || typeof personTO === 'undefined') {
+        console.log("Email addresses in TO's cannot be resolved");
+    } else {
+        for (var l = 0; l < personTO.length; l++) {
+            toEmailAddress.push(personTO[l].email);
+        }
     }
 
-    var ccEmailAddress = ''
-
-    for (var k = 0; k < personCC.length; k++) {
-        ccEmailAddress = ccEmailAddress + personCC[k].email + ","
+    var ccEmailAddress = [];
+    if (personCC === null || typeof personCC === 'undefined') {
+        console.log("Email addresses in cc cannot be resolved");
+    } else {
+        for (var k = 0; k < personCC.length; k++) {
+            ccEmailAddress.push(personCC[k].email);
+        }
     }
 
-    var bccEmailAddress = ''
-
-    for (var j = 0; j < personCC.length; j++) {
-        bccEmailAddress = bccEmailAddress + personBCC[j].email + ","
+    var bccEmailAddress = [];
+    if (personBCC === null || typeof personBCC === 'undefined') {
+        console.log("Email address in the BCC's cannot be resolved");
+    } else {
+        for (var j = 0; j < personBCC.length; j++) {
+            bccEmailAddress.push(personBCC[j].email);
+        }
     }
+
 
     var params = {
-        Destination: { /* required */
-            BccAddresses: [
-                toEmailAddress
-            ],
-            CcAddresses: [
-                ccEmailAddress
-            ],
-            ToAddresses: [
-                bccEmailAddress
-            ]
+        Destination: {
+            /* required */
+            BccAddresses: bccEmailAddress,
+            CcAddresses: ccEmailAddress,
+            ToAddresses: toEmailAddress
         },
-        Message: { /* required */
-            Body: { /* required */
+        Message: {
+            /* required */
+            Body: {
+                /* required */
                 Html: {
-                    Data: compile_template(template_name, 'html'),
+                    Data: compile_template(template_name, 'html')(null),
                     /* required */
                     Charset: 'utf8'
                 },
                 Text: {
-                    Data: compile_template(template_name, 'txt'),
+                    Data: compile_template(template_name, 'txt')(null),
                     /* required */
                     Charset: 'utf8'
                 }
@@ -159,6 +172,7 @@ function sendemails(template_name, subject, personTO, personCC, personBCC, callb
             process.env.SENDER_EMAIL_ADDRESS
         ]
     };
+    console.log("Params:" + JSON.stringify(params));
     ses.sendEmail(params, function(err, data) {
         if (err) { console.log('SES ERROR:', err, err.stack); } // an error occurred
         return callback(err, data);
@@ -167,5 +181,6 @@ function sendemails(template_name, subject, personTO, personCC, personBCC, callb
 }
 
 module.exports.email = sendemail;
+module.exports.emails = sendemails;
 module.exports.compile_template = compile_template;
 module.exports.set_template_directory = set_template_directory;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,21 +1,21 @@
 var AWS = require('aws-sdk');
 AWS.config.region = process.env.AWS_REGION;
 var ses = new AWS.SES();
-var path               = require('path');       // resolve template files
-var fs                 = require('fs');         // open tempalte files
-var Handlebars         = require('handlebars'); // compile templates
-var COMPILED_TEMPLATES = {};                    // cache compiled templates
+var path = require('path'); // resolve template files
+var fs = require('fs'); // open tempalte files
+var Handlebars = require('handlebars'); // compile templates
+var COMPILED_TEMPLATES = {}; // cache compiled templates
 
 /**
  * set_template_directory does exactly what its name suggests
  * @param {String} dir - the template directory
  */
 function set_template_directory(dir) {
-  if(!dir) {
-    throw "Please Set a Template Directory";
-  }
-  var files = fs.readdirSync(dir); // this should be sync (on startup)
-  process.env.TEMPLATE_DIRECTORY = dir; // set the env var
+    if (!dir) {
+        throw "Please Set a Template Directory";
+    }
+    var files = fs.readdirSync(dir); // this should be sync (on startup)
+    process.env.TEMPLATE_DIRECTORY = dir; // set the env var
 }
 set_template_directory(process.env.TEMPLATE_DIRECTORY);
 
@@ -25,15 +25,15 @@ set_template_directory(process.env.TEMPLATE_DIRECTORY);
  * @param {String} type - the file type
  */
 function compile_template(template_name, type) {
-  // check if the template has already been opened
-  if(!COMPILED_TEMPLATES[template_name+'.'+type]) {
-    var filepath = process.env.TEMPLATE_DIRECTORY + '/' + template_name;
-    filepath = path.resolve(filepath + '.' + type);
-    var template = fs.readFileSync(filepath, 'utf8');
-    var compiled = Handlebars.compile(template);
-    COMPILED_TEMPLATES[template_name+'.'+type] = compiled;
-  }
-  return COMPILED_TEMPLATES[template_name+'.'+type];
+    // check if the template has already been opened
+    if (!COMPILED_TEMPLATES[template_name + '.' + type]) {
+        var filepath = process.env.TEMPLATE_DIRECTORY + '/' + template_name;
+        filepath = path.resolve(filepath + '.' + type);
+        var template = fs.readFileSync(filepath, 'utf8');
+        var compiled = Handlebars.compile(template);
+        COMPILED_TEMPLATES[template_name + '.' + type] = compiled;
+    }
+    return COMPILED_TEMPLATES[template_name + '.' + type];
 }
 
 /**
@@ -48,38 +48,121 @@ function compile_template(template_name, type) {
  * the email has been sent.
  */
 function sendemail(template_name, person, callback) {
-  // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
-  var params = {
-    Destination: { /* required */
-      ToAddresses: [
-        person.email
-      ]
-    },
-    Message: { /* required */
-      Body: { /* required */
-        Html: {
-          Data: compile_template(template_name, 'html')(person), /* required */
-          Charset: 'utf8'
+    // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
+    var params = {
+        Destination: { /* required */
+            ToAddresses: [
+                person.email
+            ]
         },
-        Text: {
-          Data: compile_template(template_name, 'txt')(person), /* required */
-          Charset: 'utf8'
-        }
-      },
-      Subject: { /* required */
-        Data: person.subject, /* required */
-        Charset: 'utf8'
-      }
-    },
-    Source: person.senderEmailAddress || process.env.SENDER_EMAIL_ADDRESS, /* required */
-    ReplyToAddresses: [
-      person.replyToAddress || process.env.SENDER_EMAIL_ADDRESS
-    ]
-  };
-  ses.sendEmail(params, function(err, data) {
-    if (err) {console.log('SES ERROR:', err, err.stack);} // an error occurred
-    return callback(err, data);
-  });
+        Message: { /* required */
+            Body: { /* required */
+                Html: {
+                    Data: compile_template(template_name, 'html')(person),
+                    /* required */
+                    Charset: 'utf8'
+                },
+                Text: {
+                    Data: compile_template(template_name, 'txt')(person),
+                    /* required */
+                    Charset: 'utf8'
+                }
+            },
+            Subject: { /* required */
+                Data: person.subject,
+                /* required */
+                Charset: 'utf8'
+            }
+        },
+        Source: person.senderEmailAddress || process.env.SENDER_EMAIL_ADDRESS,
+        /* required */
+        ReplyToAddresses: [
+            person.replyToAddress || process.env.SENDER_EMAIL_ADDRESS
+        ]
+    };
+    ses.sendEmail(params, function(err, data) {
+        if (err) { console.log('SES ERROR:', err, err.stack); } // an error occurred
+        return callback(err, data);
+    });
+
+}
+
+
+/**
+ * sendemail method takes a template name and person array object for the To's, CC's & BCC and uses
+ * AWS SES to send the desired email.
+ * @param {String} template_name - the template to use for the email
+ * @param {String} subject - the subject of the email
+ * @param {Object} person - the object containing the details of the
+ * person to whom we want to send the email. Requires both name
+ * and email. if you don't *know* the name of the person, leave it
+ * an empty string.
+ * @param {Function} callback - continuation function called after
+ * the email has been sent.
+ */
+function sendemails(template_name, subject, personTO, personCC, personBCC, callback) {
+    // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
+
+
+    var toEmailAddress = ''
+
+    for (var l = 0; l < personTO.length; l++) {
+        toEmailAddress = toEmailAddress + personTO[l].email + ","
+    }
+
+    var ccEmailAddress = ''
+
+    for (var k = 0; k < personCC.length; k++) {
+        ccEmailAddress = ccEmailAddress + personCC[k].email + ","
+    }
+
+    var bccEmailAddress = ''
+
+    for (var j = 0; j < personCC.length; j++) {
+        bccEmailAddress = bccEmailAddress + personBCC[j].email + ","
+    }
+
+    var params = {
+        Destination: { /* required */
+            BccAddresses: [
+                toEmailAddress
+            ],
+            CcAddresses: [
+                ccEmailAddress
+            ],
+            ToAddresses: [
+                bccEmailAddress
+            ]
+        },
+        Message: { /* required */
+            Body: { /* required */
+                Html: {
+                    Data: compile_template(template_name, 'html'),
+                    /* required */
+                    Charset: 'utf8'
+                },
+                Text: {
+                    Data: compile_template(template_name, 'txt'),
+                    /* required */
+                    Charset: 'utf8'
+                }
+            },
+            Subject: { /* required */
+                Data: subject,
+                /* required */
+                Charset: 'utf8'
+            }
+        },
+        Source: process.env.SENDER_EMAIL_ADDRESS,
+        /* required */
+        ReplyToAddresses: [
+            process.env.SENDER_EMAIL_ADDRESS
+        ]
+    };
+    ses.sendEmail(params, function(err, data) {
+        if (err) { console.log('SES ERROR:', err, err.stack); } // an error occurred
+        return callback(err, data);
+    });
 
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,23 +1,23 @@
 var AWS = require('aws-sdk');
 AWS.config.region = process.env.AWS_REGION;
 
+
+
 function set_http_proxy() {
     var proxySet = false;
     var proxy = require('proxy-agent');
     try {
         var myproxy = process.env.HTTP_PROXY;
-
         if (myproxy === null || typeof myproxy === 'undefined') {
-            console.log("No Http proxy configured");
+            throw ("No Http proxy configured");
         } else {
             AWS.config.update({
                 httpOptions: { agent: proxy(myproxy) }
             });
-            console.log(" Http proxy configured");
             proxySet = true;
         }
     } catch (err) {
-        console.log("No proxy defined")
+        throw ("No proxy defined")
     }
     return proxySet;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,15 +1,36 @@
-var proxy = require('proxy-agent');
-var myproxy = process.env.HTTP_PROXY;
 var AWS = require('aws-sdk');
 AWS.config.region = process.env.AWS_REGION;
-AWS.config.update({
-    httpOptions: { agent: proxy(myproxy) }
-});
+
+function set_http_proxy() {
+    var proxySet = false;
+    var proxy = require('proxy-agent');
+    try {
+        var myproxy = process.env.HTTP_PROXY;
+
+        if (myproxy === null || typeof myproxy === 'undefined') {
+            console.log("No Http proxy configured");
+        } else {
+            AWS.config.update({
+                httpOptions: { agent: proxy(myproxy) }
+            });
+            console.log(" Http proxy configured");
+            proxySet = true;
+        }
+    } catch (err) {
+        console.log("No proxy defined")
+    }
+    return proxySet;
+}
+
+
+set_http_proxy();
+
 var ses = new AWS.SES();
 var path = require('path'); // resolve template files
 var fs = require('fs'); // open tempalte files
 var Handlebars = require('handlebars'); // compile templates
 var COMPILED_TEMPLATES = {}; // cache compiled templates
+
 
 
 
@@ -99,6 +120,7 @@ function sendemail(template_name, person, callback) {
  * sendemail method takes a template name and person array object for the To's, CC's & BCC and uses
  * AWS SES to send the desired email.
  * @param {String} template_name - the template to use for the email
+ * @param {Object} template_objects - the objects that will be replaced in template dynamically {{token}}
  * @param {String} subject - the subject of the email
  * @param {Object} person - the object containing the details of the
  * person to whom we want to send the email. Requires both name
@@ -107,7 +129,7 @@ function sendemail(template_name, person, callback) {
  * @param {Function} callback - continuation function called after
  * the email has been sent.
  */
-function sendemails(template_name, subject, personTO, personCC, personBCC, callback) {
+function sendemails(template_name, template_objects, subject, personTO, personCC, personBCC, callback) {
     // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
 
     var toEmailAddress = [];
@@ -137,7 +159,6 @@ function sendemails(template_name, subject, personTO, personCC, personBCC, callb
         }
     }
 
-
     var params = {
         Destination: {
             /* required */
@@ -150,12 +171,12 @@ function sendemails(template_name, subject, personTO, personCC, personBCC, callb
             Body: {
                 /* required */
                 Html: {
-                    Data: compile_template(template_name, 'html')(null),
+                    Data: compile_template(template_name, 'html')(template_objects),
                     /* required */
                     Charset: 'utf8'
                 },
                 Text: {
-                    Data: compile_template(template_name, 'txt')(null),
+                    Data: compile_template(template_name, 'txt')(template_objects),
                     /* required */
                     Charset: 'utf8'
                 }
@@ -172,7 +193,7 @@ function sendemails(template_name, subject, personTO, personCC, personBCC, callb
             process.env.SENDER_EMAIL_ADDRESS
         ]
     };
-    console.log("Params:" + JSON.stringify(params));
+    //console.log("Params:" + JSON.stringify(params));
     ses.sendEmail(params, function(err, data) {
         if (err) { console.log('SES ERROR:', err, err.stack); } // an error occurred
         return callback(err, data);
@@ -184,3 +205,4 @@ module.exports.email = sendemail;
 module.exports.emails = sendemails;
 module.exports.compile_template = compile_template;
 module.exports.set_template_directory = set_template_directory;
+module.exports.set_http_proxy = set_http_proxy;

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   ],
   "dependencies": {
     "aws-sdk": "^2.3.7",
-    "handlebars": "^4.0.3"
+    "handlebars": "^4.0.3",
+    "proxy-agent": "^2.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,7 @@ require('env2')('.env');
 var sendemail = require('../lib/index.js'); // auto-set TEMPLATE_DIR
 var email = sendemail.email;
 var emails = sendemail.emails;
+var set_http_proxy = sendemail.set_http_proxy;
 var path = require('path');
 var test = require('tape');
 var dir = __dirname.split('/')[__dirname.split('/').length - 1];
@@ -122,7 +123,11 @@ test(file + " send email To CC BCC (Success)", function(t) {
     var personCC = [person2CC, person1To]
     var personBCC = [person3BCC, person2CC]
 
-    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+    var templateObjects = {
+        mydate: 'Feb 17 2017'
+    }
+
+    emails('hello', templateObjects, 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
         //console.log(err, data);
         t.ok(data.MessageId.length > 0, 'Email Sent!');
         t.end()
@@ -150,7 +155,11 @@ test(file + " send email To CC(Success)", function(t) {
     var personCC = [person2CC];
     var personBCC = null;
 
-    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+    var templateObjects = {
+        mydate: 'Feb 17 2017'
+    }
+
+    emails('hello', templateObjects, 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
         //console.log(err, data);
         t.ok(data.MessageId.length > 0, 'Email Sent!');
         t.end()
@@ -167,7 +176,11 @@ test(file + " send email To (Success)", function(t) {
     var personCC = [person2CC];
     var personBCC = null;
 
-    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+    var templateObjects = {
+        mydate: 'Feb 17 2017'
+    }
+
+    emails('hello', templateObjects, 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
         //console.log(err, data);
         t.ok(data.MessageId.length > 0, 'Email Sent!');
         t.end()
@@ -187,7 +200,11 @@ test(file + " send email CC (Success)", function(t) {
     var personCC = null;
     var personBCC = null;
 
-    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+    var templateObjects = {
+        mydate: 'Feb 17 2017'
+    }
+
+    emails('hello', templateObjects, 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
         //console.log(err, data);
         t.ok(data.MessageId.length > 0, 'Email Sent!');
         t.end()
@@ -215,7 +232,11 @@ test(file + " send email To BCC(Success)", function(t) {
     var personCC = null;
     var personBCC = [person3BCC];
 
-    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+    var templateObjects = {
+        mydate: 'Feb 17 2017'
+    }
+
+    emails('hello', templateObjects, 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
         //console.log(err, data);
         t.ok(data.MessageId.length > 0, 'Email Sent!');
         t.end()
@@ -243,9 +264,23 @@ test(file + " send email All null(Force Failure)", function(t) {
     var personCC = null;
     var personBCC = null;
 
-    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+    var templateObjects = {
+        mydate: 'Feb 17 2017'
+    }
+
+    emails('hello', templateObjects, 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
         //console.log(err, data);
         t.equal(err.statusCode, 400, "No Email Address provided");
         t.end()
     })
+});
+
+var AWS = require('aws-sdk');
+
+test(file + " check for proxy", function(t) {
+
+    var x = set_http_proxy();
+
+    t.ok(x, true, "Proxy Set")
+    t.end();
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -278,9 +278,18 @@ test(file + " send email All null(Force Failure)", function(t) {
 var AWS = require('aws-sdk');
 
 test(file + " check for proxy", function(t) {
-
     var x = set_http_proxy();
-
     t.ok(x, true, "Proxy Set")
     t.end();
+});
+
+test(file + "check if proxy is not configured", function(t) {
+    delete process.env.HTTP_PROXY;
+    try {
+        var x = set_http_proxy();
+    } catch (err) {
+        t.equals(err, "No proxy defined", "Proxy not configured");
+        t.end();
+    }
+
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,98 +1,132 @@
 require('env2')('.env');
 var sendemail = require('../lib/index.js'); // auto-set TEMPLATE_DIR
-var email     = sendemail.email;
-var path      = require('path');
-var test      = require('tape');
-var dir       = __dirname.split('/')[__dirname.split('/').length-1];
-var file      = dir + __filename.replace(__dirname, '');
-var decache   = require('decache');
+var email = sendemail.email;
+var path = require('path');
+var test = require('tape');
+var dir = __dirname.split('/')[__dirname.split('/').length - 1];
+var file = dir + __filename.replace(__dirname, '');
+var decache = require('decache');
 
 var TEMPLATE_DIR = process.env.TEMPLATE_DIRECTORY; // copy
-delete process.env.TEMPLATE_DIRECTORY;             // delete
+delete process.env.TEMPLATE_DIRECTORY; // delete
 
-test(file+" process.env.TEMPLATE_DIRECTORY has been unset", function(t) {
-  t.equal(process.env.TEMPLATE_DIRECTORY, undefined, "Not Set (as expected)");
-  t.end();
-});
-
-test(file+" set_template_directory without args throws error!", function(t) {
-  try {
-    sendemail.set_template_directory();
-  } catch (e) {
-    t.ok(e.indexOf('Please Set a Template Directory') > -1, 'Error Thrown: '+e)
+test(file + " process.env.TEMPLATE_DIRECTORY has been unset", function(t) {
     t.equal(process.env.TEMPLATE_DIRECTORY, undefined, "Not Set (as expected)");
     t.end();
-  }
 });
 
-test(file+" set_template_directory with INVALID directory!", function(t) {
-  try {
-    sendemail.set_template_directory('/invalid');
-  } catch (e) {
-    console.log(e.code);
-    t.ok(e.code === 'ENOENT', 'FS Error: '+JSON.stringify(e))
-    t.equal(process.env.TEMPLATE_DIRECTORY, undefined, "Not Set (as expected)");
-    t.end();
-  }
+test(file + " set_template_directory without args throws error!", function(t) {
+    try {
+        sendemail.set_template_directory();
+    } catch (e) {
+        t.ok(e.indexOf('Please Set a Template Directory') > -1, 'Error Thrown: ' + e)
+        t.equal(process.env.TEMPLATE_DIRECTORY, undefined, "Not Set (as expected)");
+        t.end();
+    }
 });
 
-test(file+" attempt to compile non-existent template (fail!)", function(t) {
-  try {
-    process.env.TEMPLATE_DIRECTORY = TEMPLATE_DIR;
-    console.log('TEMPLATE_DIR:', TEMPLATE_DIR);
-    sendemail.compile_template('no-file.html');
-  } catch (e) {
-    t.ok(e.code === 'ENOENT', 'FS Error: '+JSON.stringify(e))
-    t.end();
-  }
+test(file + " set_template_directory with INVALID directory!", function(t) {
+    try {
+        sendemail.set_template_directory('/invalid');
+    } catch (e) {
+        console.log(e.code);
+        t.ok(e.code === 'ENOENT', 'FS Error: ' + JSON.stringify(e))
+        t.equal(process.env.TEMPLATE_DIRECTORY, undefined, "Not Set (as expected)");
+        t.end();
+    }
+});
+
+test(file + " attempt to compile non-existent template (fail!)", function(t) {
+    try {
+        process.env.TEMPLATE_DIRECTORY = TEMPLATE_DIR;
+        console.log('TEMPLATE_DIR:', TEMPLATE_DIR);
+        sendemail.compile_template('no-file.html');
+    } catch (e) {
+        t.ok(e.code === 'ENOENT', 'FS Error: ' + JSON.stringify(e))
+        t.end();
+    }
 });
 
 var Handlebars = require('handlebars');
 
-test(file+" compile a known template", function(t) {
-  var c = sendemail.compile_template('hello', 'html');
-  var result = c({name:'Jimmy'});
-  t.ok(result.indexOf("<p>Hello Jimmy!</p>") > -1, 'Rendered: '+result);
-  t.end()
-});
-
-test(file+" compile .html template from cache", function(t) {
-  var c = sendemail.compile_template('hello', 'html');
-  var result = c({name:'Jenny'});
-  t.ok(result.indexOf("<p>Hello Jenny!</p>") > -1, 'Rendered: '+result);
-  t.end()
-});
-
-test(file+" compile .txt template", function(t) {
-  var c = sendemail.compile_template('hello', 'txt');
-  var result = c({name:'Jenny'});
-  t.ok(result.indexOf("Hello Jenny!") > -1, 'Rendered: '+result);
-  t.end()
-});
-
-test(file+" Force Fail in Email", function(t) {
-  var person = {
-    "name"     : "Bounce",
-    "email"    : "invalid.email.address",
-    "subject":"Welcome to DWYL :)"
-  };
-  email('hello', person, function(err, data) {
-    // console.log(' - - - - - - - - - - - ');
-    // console.log(err, data);
-    t.equal(err.statusCode, 400, "Invalid Mandrill Key");
-    t.end();
-  })
-});
-
-test(file+" send email (Success)", function(t) {
-  var person = {
-    name : "Success",
-    email: "success@simulator.amazonses.com",
-    "subject":"Welcome to DWYL :)"
-  }
-  email('hello', person, function(err, data){
-    // console.log(err, data);
-    t.ok(data.MessageId.length > 0, 'Email Sent!');
+test(file + " compile a known template", function(t) {
+    var c = sendemail.compile_template('hello', 'html');
+    var result = c({ name: 'Jimmy' });
+    t.ok(result.indexOf("<p>Hello Jimmy!</p>") > -1, 'Rendered: ' + result);
     t.end()
-  })
+});
+
+test(file + " compile .html template from cache", function(t) {
+    var c = sendemail.compile_template('hello', 'html');
+    var result = c({ name: 'Jenny' });
+    t.ok(result.indexOf("<p>Hello Jenny!</p>") > -1, 'Rendered: ' + result);
+    t.end()
+});
+
+test(file + " compile .txt template", function(t) {
+    var c = sendemail.compile_template('hello', 'txt');
+    var result = c({ name: 'Jenny' });
+    t.ok(result.indexOf("Hello Jenny!") > -1, 'Rendered: ' + result);
+    t.end()
+});
+
+
+
+test(file + " send email (Success)", function(t) {
+    var person = {
+        name: "Success",
+        email: "success@simulator.amazonses.com",
+        "subject": "Welcome to DWYL :)"
+    }
+    email('hello', person, function(err, data) {
+        // console.log(err, data);
+        t.ok(data.MessageId.length > 0, 'Email Sent!');
+        t.end()
+    })
+});
+
+test(file + " send email To CC BCC (Success)", function(t) {
+    var person1To = {
+        name: "Success1",
+        email: "success@simulator.amazonses.com",
+        "subject": "Welcome to DWYL :)"
+    }
+    var person2CC = {
+        name: "Success2",
+        email: "success@simulator.amazonses.com",
+        "subject": "Welcome to DWYL :)"
+    }
+    var person3BCC = {
+        name: "Success3",
+        email: "success@simulator.amazonses.com",
+        "subject": "Welcome to DWYL :)"
+    }
+    var person4To = {
+        name: "Success4",
+        email: "success@simulator.amazonses.com",
+        "subject": "Welcome to DWYL :)"
+    }
+    var personTo = [person1To, person4To]
+    var personCC = [person2CC]
+    var personBCC = [person3BCC]
+
+    email('hello', personTo, personCC, personBCC, function(err, data) {
+        // console.log(err, data);
+        t.ok(data.MessageId.length > 0, 'Email Sent!');
+        t.end()
+    })
+});
+
+test(file + " Force Fail in Email", function(t) {
+    var person = {
+        "name": "Bounce",
+        "email": "invalid.email.address",
+        "subject": "Welcome to DWYL :)"
+    };
+    email('hello', person, function(err, data) {
+        // console.log(' - - - - - - - - - - - ');
+        // console.log(err, data);
+        t.equal(err.statusCode, 400, "Invalid Mandrill Key");
+        t.end();
+    })
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,11 +1,13 @@
 require('env2')('.env');
 var sendemail = require('../lib/index.js'); // auto-set TEMPLATE_DIR
 var email = sendemail.email;
+var emails = sendemail.emails;
 var path = require('path');
 var test = require('tape');
 var dir = __dirname.split('/')[__dirname.split('/').length - 1];
 var file = dir + __filename.replace(__dirname, '');
 var decache = require('decache');
+
 
 var TEMPLATE_DIR = process.env.TEMPLATE_DIRECTORY; // copy
 delete process.env.TEMPLATE_DIRECTORY; // delete
@@ -76,41 +78,9 @@ test(file + " send email (Success)", function(t) {
     var person = {
         name: "Success",
         email: "success@simulator.amazonses.com",
-        "subject": "Welcome to DWYL :)"
+        subject: "Welcome to DWYL :)"
     }
     email('hello', person, function(err, data) {
-        // console.log(err, data);
-        t.ok(data.MessageId.length > 0, 'Email Sent!');
-        t.end()
-    })
-});
-
-test(file + " send email To CC BCC (Success)", function(t) {
-    var person1To = {
-        name: "Success1",
-        email: "success@simulator.amazonses.com",
-        "subject": "Welcome to DWYL :)"
-    }
-    var person2CC = {
-        name: "Success2",
-        email: "success@simulator.amazonses.com",
-        "subject": "Welcome to DWYL :)"
-    }
-    var person3BCC = {
-        name: "Success3",
-        email: "success@simulator.amazonses.com",
-        "subject": "Welcome to DWYL :)"
-    }
-    var person4To = {
-        name: "Success4",
-        email: "success@simulator.amazonses.com",
-        "subject": "Welcome to DWYL :)"
-    }
-    var personTo = [person1To, person4To]
-    var personCC = [person2CC]
-    var personBCC = [person3BCC]
-
-    email('hello', personTo, personCC, personBCC, function(err, data) {
         // console.log(err, data);
         t.ok(data.MessageId.length > 0, 'Email Sent!');
         t.end()
@@ -128,5 +98,154 @@ test(file + " Force Fail in Email", function(t) {
         // console.log(err, data);
         t.equal(err.statusCode, 400, "Invalid Mandrill Key");
         t.end();
+    })
+});
+
+test(file + " send email To CC BCC (Success)", function(t) {
+    var person1To = {
+        name: "Success1",
+        email: "success@simulator.amazonses.com"
+    }
+    var person2CC = {
+        name: "Success2",
+        email: "success@simulator.amazonses.com"
+    }
+    var person3BCC = {
+        name: "Success3",
+        email: "success@simulator.amazonses.com"
+    }
+    var person4To = {
+        name: "Success4",
+        email: "success@simulator.amazonses.com"
+    }
+    var personTo = [person1To, person4To]
+    var personCC = [person2CC, person1To]
+    var personBCC = [person3BCC, person2CC]
+
+    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+        //console.log(err, data);
+        t.ok(data.MessageId.length > 0, 'Email Sent!');
+        t.end()
+    })
+});
+
+test(file + " send email To CC(Success)", function(t) {
+    var person1To = {
+        name: "Success1",
+        email: "success@simulator.amazonses.com"
+    };
+    var person2CC = {
+        name: "Success2",
+        email: "success@simulator.amazonses.com"
+    };
+    var person3BCC = {
+        name: "Success3",
+        email: "success@simulator.amazonses.com"
+    };
+    var person4To = {
+        name: "Success4",
+        email: "success@simulator.amazonses.com"
+    };
+    var personTo = [person1To, person4To];
+    var personCC = [person2CC];
+    var personBCC = null;
+
+    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+        //console.log(err, data);
+        t.ok(data.MessageId.length > 0, 'Email Sent!');
+        t.end()
+    })
+});
+
+
+test(file + " send email To (Success)", function(t) {
+    var person2CC = {
+        name: "Success2",
+        email: "success@simulator.amazonses.com"
+    }
+    var personTo = null;
+    var personCC = [person2CC];
+    var personBCC = null;
+
+    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+        //console.log(err, data);
+        t.ok(data.MessageId.length > 0, 'Email Sent!');
+        t.end()
+    })
+});
+
+test(file + " send email CC (Success)", function(t) {
+    var person1To = {
+        name: "Success1",
+        email: "success@simulator.amazonses.com"
+    };
+    var person4To = {
+        name: "Success4",
+        email: "success@simulator.amazonses.com"
+    };
+    var personTo = [person1To, person4To];
+    var personCC = null;
+    var personBCC = null;
+
+    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+        //console.log(err, data);
+        t.ok(data.MessageId.length > 0, 'Email Sent!');
+        t.end()
+    })
+});
+
+test(file + " send email To BCC(Success)", function(t) {
+    var person1To = {
+        name: "Success1",
+        email: "success@simulator.amazonses.com"
+    };
+    var person2CC = {
+        name: "Success2",
+        email: "success@simulator.amazonses.com"
+    };
+    var person3BCC = {
+        name: "Success3",
+        email: "success@simulator.amazonses.com"
+    };
+    var person4To = {
+        name: "Success4",
+        email: "success@simulator.amazonses.com"
+    };
+    var personTo = [person1To, person4To];
+    var personCC = null;
+    var personBCC = [person3BCC];
+
+    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+        //console.log(err, data);
+        t.ok(data.MessageId.length > 0, 'Email Sent!');
+        t.end()
+    })
+});
+
+test(file + " send email All null(Force Failure)", function(t) {
+    var person1To = {
+        name: "Success1",
+        email: "success@simulator.amazonses.com"
+    };
+    var person2CC = {
+        name: "Success2",
+        email: "success@simulator.amazonses.com"
+    };
+    var person3BCC = {
+        name: "Success3",
+        email: "success@simulator.amazonses.com"
+    };
+    var person4To = {
+        name: "Success4",
+        email: "success@simulator.amazonses.com"
+    };
+    var personTo = null;
+    var personCC = null;
+    var personBCC = null;
+
+    emails('hello', 'Welcome to Email', personTo, personCC, personBCC, function(err, data) {
+        //console.log(err, data);
+        t.equal(err.statusCode, 400, "No Email Address provided");
+        t.end()
     })
 });


### PR DESCRIPTION
- Supports passing of email address array as person objects for To, CC & BCC fields
- Add supports for corporate proxy if needed
- Works with IAM role and AWS Short token service generated in your aws config
- Unit test 100% coverage for the added code.
- Fixes #63 

ENV file format can be as below for newer fields
```
export TEMPLATE_DIRECTORY=examples/templates
export SENDER_EMAIL_ADDRESS=who@anyone.com
export AWS_PROFILE=<if you have any profile - this fields is optional>
export AWS_REGION=us-east-1
export HTTP_PROXY=http://localhost:8099
export HTTPS_PROXY=https://localhost:8099
export https_proxy=$HTTP_PROXY
export http_proxy=$HTTP_PROXY
export NO_PROXY=169.254.169.254
```