### PR TITLE
Mailgun integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ of technical decisions (*for pragmatic reasons*):
 1. use [***environment variables***](https://github.com/dwyl/learn-environment-variables)
 for storing sensitive information (*API Keys*)
 and projects-specific configuration (*Template Directory*)
-2. use ***[Amazon Web Services Simple Email Service](https://aws.amazon.com/ses/getting-started/) ("AWS SES")***
-for *reliably* sending email messages because it has good documentation,
-excellent "*deliverability*" and ***no minimum*** spend (10 cents per 1000 emails sent)!
-(_there's also a **generous** "[**Free Tier**](https://aws.amazon.com/ses/pricing/)" of **65k emails per month** if you're new to AWS_)
-3. use ***Handlebars*** for email template rendering. Handlebars is very
+2. use ***Handlebars*** for email template rendering. Handlebars is very
 easy to use and allows us to send ***beautiful*** **HTML** emails without
 the complexity or learning curve of many other view libraries.
+3. We currently support the following Email Services
+
+    - **[Amazon Web Services Simple Email Service](https://aws.amazon.com/ses/getting-started/) ("AWS SES")**
+    - **[Mailgun](https://www.mailgun.com/)**
+
+Both are reliable, well-documented, offer excellent "*deliverability*", and have fairly generous free tiers.
+For more information, check out the [Technical/Implementation Detail](#technical/implementation-detail) below
 
 > **Note**: if you prefer to use a different Email Service provider or template/view
 library for your project,
@@ -60,15 +63,15 @@ people with *specific needs*.
 
 ### Checklist (*everything you need to get started in 5 minutes*)
 + [ ] install the `sendemail` module from NPM
-+ [ ] Ensure that you have an AWS Account and have downloaded your credentials.
-+ [ ] set the required [*environment variable*](https://github.com/dwyl/learn-environment-variables) (*see below*)
++ [ ] Ensure that you have an an account on your email service of choice
++ [ ] set the required [*environment variables*](https://github.com/dwyl/learn-environment-variables) (*see below*)
 + [ ] If you don't already have a /**templates** directory in your
 project create one!
 + [ ] create a pair of email templates in your /**templates** directory
 one called `hello.txt` the other `hello.html`
 + [ ] borrow the code for `hello.txt` and `hello.html` from the **/examples/templates** directory of this project!
 + [ ] create a file called `welcome.js` and paste some sample
-code in it (see: [/examples/templates/**send-welcome-email.js**]() )
+code in it (see: [/examples/templates/**send-welcome-email.js**](/examples/templates/send-welcome-email.js) )
 
 ### 1. Install `sendemail` from NPM
 
@@ -78,20 +81,32 @@ npm install sendemail --save
 
 ### 2. Set your *Environment Variables*
 
-`sendemail` requires you set ***four*** environment variable to
-*securely* store your AWS API Keys.
+`sendemail` requires you set environment variables for your email service's API keys
 
 > We recommend you use [`env2`](https://github.com/dwyl/env2) to load your
 Environment Variables from a file so you can easily keep track of which
 variables you are using in each environment.
 
-Create a file in the root of your project called `.env` and paste the following:
+Create a file in the root of your project called `.env` and paste the following, varying by email service:
+
+#### AWS SES
+
 ```sh
 export TEMPLATE_DIRECTORY=./examples/templates
 export SENDER_EMAIL_ADDRESS=your.aws.verified.email.address@gmail.com
 export AWS_REGION=eu-west-1
 export AWS_ACCESS_KEY_ID=YOURKEY
 export AWS_SECRET_ACCESS_KEY=YOURSUPERSECRET
+```
+
+#### Mailgun
+
+```sh
+export TEMPLATE_DIRECTORY=./examples/templates
+TODO Confirm Mailgun requires verifying email addresses
+export SENDER_EMAIL_ADDRESS=your.mailgun.verified.email.address@gmail.com
+export MAILGUN_API_KEY=YOURKEY
+export MAILGUN_SENDING_DOMAIN=YOURDOMAIN
 ```
 
 > If you are ***new*** to ***environment variables***, we have a
@@ -143,19 +158,19 @@ email('welcome', person, function(error, result){
 
 For *full code of working example* see: [/examples/templates/**send-welcome-email.js**](https://github.com/dwyl/sendemail/blob/master/examples/send-welcome-email.js)
 Note: you still need to set your *environment variables*
-for the email to be sent.
+for the email to be sent. The example will work regardless of which service you use; our public API is platform agnostic TODO Is this true?
 
 
 #### More Options?:
 
-If you wish to send to multiple recipients of include CC or BCC recipients,
-use the sendMany method. This allows you to provide an options object 
-with an array of `toAddresses`, `ccAddresses`, and `bccAddresses` and charset options. 
+If you wish to send to multiple recipients or include CC or BCC recipients,
+use the sendMany method. This allows you to provide an options object
+with an array of `toAddresses`, `ccAddresses`, and `bccAddresses` and charset options.
  e.g.
- 
+
 ```js
   var sendemail   = require('sendemail');
-  
+
   var options = {
     templateName: 'hello',
     context: {
@@ -183,15 +198,26 @@ ___
 ### Which Email Service Provider?
 
 We are *currently* using ***AWS SES*** for ***dwyl***.
+We also support **Mailgun**
 
 If you want to use an alternative mail sender,
-e.g: [sendgrid](http://sendgrid.com/)
-or [mailgun](https://www.mailgun.com/pricing)
+e.g: [sendgrid](http://sendgrid.com/), [sendinblue](https://www.sendinblue.com/), etc.
+
 please ***tell us***: https://github.com/dwyl/sendemail/issues
 (*we are* ***always*** *happy to help*)
 
 
-### Moving out of AWS SES sandbox environment.
+### Moving out of a sandbox environment.
+
+Whether you choose AWS or Mailgun, you start off in a _sandbox environment_
+
+This means, generally:
+- low limit on the number of emails you can send (usually daily allowance)
+- you can send to and from only verified (manually whitelisted) email addresses, not any random email address from a random person stumbling across your site as in production use
+
+You're going to want to move out of this environment for sending email on a public project (in most cases)
+
+#### AWS SES
 
 When you first sign up to AWS, you are provided with a _sandbox account_.
 With this, you can send up to *200 emails a day,* to email addresses that you
@@ -206,8 +232,20 @@ increase in your SES Sending Limit; (1) click on the following link,
 https://aws.amazon.com/ses/faqs/ (2) search for "apply" in section 4 and
 (3) click 'apply'.
 
+#### Mailgun
 
-### Which View/Template Libaray?
+When you first sign up, Mailgun will provide a sandbox domain, which you can send from to test your integration. While in this sandbox, without a verified domain, you are limited to *300 emails per day*
+
+Once you're happy with your integration, you'll need to do the following:
+
+1. *Upgrade your account* This requires entering your credit card information. **Mailgun charges you only if you exceed your free monthly allowance (10,000 emails sent)**
+2. Add your website's domain to your account
+3. Go into your DNS registrar's account and create SPF and DKIM records, standard TXT records for signing emails sent from your domain that email servers receiving your mail use to verify that the message sent is legitimately from your domain ( *Mailgun provides the values for these records in your dashboard* ) instead of rejecting your messages because the recipient server wasn't sent from the domain the message is claiming it was sent from.
+    - Interested in learning more? Here's a [short, simple read explaining DKIM and SPF](https://blog.woodpecker.co/cold-email/spf-dkim/)
+4. Wait for Mailgun to verify that the records are set. Like any other DNS changes, this may take 24-48 hours (though typically much less)
+
+
+### Which View/Template Libaray?
 
 For *simplicity* we are using
 [***Handlebars***](http://handlebarsjs.com/),
@@ -233,8 +271,7 @@ In our *experience*, *while* most *modern* email clients
 have `HTML` email ***enabled by default***,
 *often* the people who *prefer* ***text-only***
 (e.g: people with Blackberry phones,
-***visual/physical impairment*** or *company* email
-email systems - *with aggressive filtering*)
+***visual/physical impairment*** or *company* email systems - *with aggressive filtering*)
 are "***higher value***" customers. Also,
 possibly *more importantly* (*depending on who is using your product/service*) you can have *technical privacy-concious* people
 that ***only*** read `.txt` email to avoid sending
@@ -250,7 +287,7 @@ you can instead assume that the third party method will give back what they say 
 (since these tests should already exist in the library you are using).
 
 Once you are sure there are [sufficient tests in place](https://codecov.io/github/dwyl/sendemail?branch=master) for the method you will stub, you may proceed with a test double.
-For this library there are significant benefits for using a test double for the `email` method (see #49).
+For this library there are significant benefits for using a test double for the `email` method (see [#49](https://github.com/dwyl/sendemail/issues/49)).
 
 ###### The following is a quick example of how to implement a test stub:
 If you have a helper function `notifyUser` which will subsequently call `require('sendemail').email`, this can be stubbed with:
@@ -298,7 +335,7 @@ Check out the [article in background reading](https://semaphoreci.com/community/
 
 ## Useful Links:
 
-### Background Reading
+### Background Reading
 
 + Designing for the inbox:
 https://www.campaignmonitor.com/dev-resources/guides/design/
@@ -315,11 +352,24 @@ https://semaphoreci.com/community/tutorials/best-practices-for-spies-stubs-and-m
 
 ### Technical/Implementation Detail
 
+#### AWS SES
+
 + Detail: https://aws.amazon.com/ses/details/
 + Getting Started: https://aws.amazon.com/ses/getting-started/
 + Video Tutorial: https://www.youtube.com/watch?v=0NT8KRXRFG8
 + Basic Tutorial: http://timstermatic.github.io/blog/2013/08/14/sending-emails-with-node-dot-js-and-amazon-ses/
 + Testing: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/mailbox-simulator.html
++ Pricing: https://aws.amazon.com/ses/pricing/
+
+#### Mailgun
+
+We opted to use an independent Mailgun JavaScript client — https://github.com/bojand/mailgun-js — over [Mailgun's official JS library](https://github.com/mailgun/mailgun-js) because the independent library is more actively maintained and the maintainer appears to accept PRs from anyone interested in and willing to contribute to and improve their work. Given the 2 libraries are comparable in functionality, we opted to work with a library more likely to continue working seamlessly (or at least be open to bug fixes; fingers crossed no issues, though :) )
+
++ Detail: https://www.mailgun.com/sending-email
++ Getting Started: https://documentation.mailgun.com/en/latest/quickstart.html
+  + The code samples there are, of course, using Mailgun's official library, not the independent one
++ Basic Tutorial: http://blog.mailgun.com/how-to-send-transactional-emails-in-a-nodejs-app-using-the-mailgun-api/
++ Pricing: https://www.mailgun.com/pricing
 
 ### Stats/Trends
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ export AWS_SECRET_ACCESS_KEY=YOURSUPERSECRET
 
 ```sh
 export TEMPLATE_DIRECTORY=./examples/templates
-TODO Confirm Mailgun requires verifying email addresses
-export SENDER_EMAIL_ADDRESS=your.mailgun.verified.email.address@gmail.com
+export SENDER_EMAIL_ADDRESS=your.sending.email.address@gmail.com
 export MAILGUN_API_KEY=YOURKEY
 export MAILGUN_SENDING_DOMAIN=YOURDOMAIN
 ```
@@ -235,6 +234,9 @@ https://aws.amazon.com/ses/faqs/ (2) search for "apply" in section 4 and
 #### Mailgun
 
 When you first sign up, Mailgun will provide a sandbox domain, which you can send from to test your integration. While in this sandbox, without a verified domain, you are limited to *300 emails per day*
+
+Moreover, while you can send from any email address, you can send TO only verified email
+addresses (requires a manual email verification step with the inbox owner)
 
 Once you're happy with your integration, you'll need to do the following:
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,10 @@
 'use strict';
 
-var AWS = require('aws-sdk');
-var ses = new AWS.SES();
 var path = require('path');             // -> resolve template files
 var fs = require('fs');                 // -> open template files
 var Handlebars = require('handlebars'); // -> compile templates
 var COMPILED_TEMPLATES = {};            // -> cache compiled templates
-
-AWS.config.region = process.env.AWS_REGION;
+var Send = require('./service').send;     // -> email service, for sending
 
 /**
  * set_template_directory does exactly what its name suggests
@@ -50,11 +47,13 @@ function isTruthy (x) {
   return Boolean(x);
 }
 
+// TODO Review this docblock, make sure still current
+// TODO Add injectService to docblock
 /**
  * sendMany function is similar to sendemail but allows more control
  * of params including multiple recipients and CC and BCC recipients
  *
- * @param {Object} options
+ * @param {Object} options -
  * @param {String[]} options.toAddresses - The recipient emails addresses
  * @param {String[]} [options.ccAddresses] - The cc recipient emails addresses
  * @param {String[]} [options.bccAddresses] - The bcc recipient emails addresses
@@ -68,60 +67,38 @@ function isTruthy (x) {
  * @param {String} [options.textCharset] - charset for text email body
  * @param {String} [options.subjectCharset] - charset for email subject
  * @param {Function} callback - continuation function called after
- * the email has been sent. */
-
-function sendMany (options, callback) {
+ * the email has been sent.
+ * @param {String} specific_serivice - name of sending service to use
+ * assuming set configuration, overriding default in the case of competing
+ * service configurations (valid values are keys on SERVICE_CONFIGS object in lib/service.js).
+ * @returns {undefined}
+ */
+function sendMany (options, callback, specific_service) {
+  // TODO Where does this go now?
   /* eslint-disable max-len */
   // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
 
-  var toAddresses = options.toAddresses || [];
-  var ccAddresses = options.ccAddresses || [];
-  var bccAddresses = options.bccAddresses || [];
-  var defaultCharset = 'utf8';
-  var params;
+  // Deep clones options, ensures no mutation of input (deep necessary because source may contain arrays)
+  var clean_options = JSON.parse(JSON.stringify(options));
 
-  toAddresses = toAddresses.filter(isTruthy);
-  ccAddresses = ccAddresses.filter(isTruthy);
-  bccAddresses = bccAddresses.filter(isTruthy);
+  clean_options.senderEmailAddress = clean_options.senderEmailAddress || process.env.SENDER_EMAIL_ADDRESS
+  clean_options.toAddresses = clean_options.toAddresses || [];
+  clean_options.ccAddresses = clean_options.ccAddresses || [];
+  clean_options.bccAddresses = clean_options.bccAddresses || [];
+  clean_options.replyToAddress = clean_options.replyToAddress || process.env.SENDER_EMAIL_ADDRESS;
+  clean_options.defaultCharset = 'utf8';
 
-  params = {
-    Destination: {
-      /* required */
-      BccAddresses: bccAddresses,
-      CcAddresses: ccAddresses,
-      ToAddresses: toAddresses
-    },
-    Message: {
-      /* required */
-      Body: {
-        /* required */
-        Html: {
-          Data: compile_template(options.templateName, 'html')(options.context),
-          /* required */
-          Charset: options.htmlCharset || defaultCharset
-        },
-        Text: {
-          Data: compile_template(options.templateName, 'txt')(options.context),
-          /* required */
-          Charset: options.textCharset || defaultCharset
-        }
-      },
-      Subject: {
-        /* required */
-        Data: options.subject,
-        /* required */
-        Charset: options.subjectCharset || defaultCharset
-      }
-    },
-    Source: options.senderEmailAddress || process.env.SENDER_EMAIL_ADDRESS, /* required */
-    ReplyToAddresses: [
-      options.replyToAddress || process.env.SENDER_EMAIL_ADDRESS
-    ]
-  };
+  clean_options.toAddresses = clean_options.toAddresses.filter(isTruthy);
+  clean_options.ccAddresses = clean_options.ccAddresses.filter(isTruthy);
+  clean_options.bccAddresses = clean_options.bccAddresses.filter(isTruthy);
 
-  ses.sendEmail(params, callback);
+  clean_options.html_body = compile_template(clean_options.templateName, 'html')(clean_options.context);
+  clean_options.txt_body = compile_template(clean_options.templateName, 'txt')(clean_options.context);
+
+  Send(clean_options, callback, specific_service);
 }
 
+// TODO Add injectedService to docblock
 /**
  * sendemail method takes a template name and person object and uses
  * AWS SES to send the desired email.
@@ -132,9 +109,12 @@ function sendMany (options, callback) {
  * an empty string.
  * @param {Function} callback - continuation function called after
  * the email has been sent.
+ * @param {String} specific_serivice - name of sending service to use
+ * assuming set configuration, overriding default in the case of competing
+ * service configurations (valid values are keys on SERVICE_CONFIGS object in lib/service.js).
  * @returns {undefined}
  */
-function sendemail (template_name, person, callback) {
+function sendemail (template_name, person, callback, specific_service) {
   var options = {
     templateName: template_name,
     context: person,
@@ -146,9 +126,8 @@ function sendemail (template_name, person, callback) {
     bccAddresses: null
   };
 
-  sendMany(options, callback);
+  sendMany(options, callback, specific_service);
 }
-
 
 module.exports.email = sendemail;
 module.exports.sendMany = sendMany;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var path = require('path');             // -> resolve template files
 var fs = require('fs');                 // -> open template files
 var Handlebars = require('handlebars'); // -> compile templates
 var COMPILED_TEMPLATES = {};            // -> cache compiled templates
-var Send = require('./service').send;     // -> email service, for sending
+var send = require('./service').send;     // -> email service, for sending
 
 /**
  * set_template_directory does exactly what its name suggests
@@ -48,7 +48,6 @@ function isTruthy (x) {
 }
 
 // TODO Review this docblock, make sure still current
-// TODO Add injectService to docblock
 /**
  * sendMany function is similar to sendemail but allows more control
  * of params including multiple recipients and CC and BCC recipients
@@ -68,20 +67,15 @@ function isTruthy (x) {
  * @param {String} [options.subjectCharset] - charset for email subject
  * @param {Function} callback - continuation function called after
  * the email has been sent.
- * @param {String} specific_serivice - name of sending service to use
- * assuming set configuration, overriding default in the case of competing
- * service configurations (valid values are keys on SERVICE_CONFIGS object in lib/service.js).
  * @returns {undefined}
  */
-function sendMany (options, callback, specific_service) {
-  // TODO Where does this go now?
+function sendMany (options, callback) {
   /* eslint-disable max-len */
-  // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
 
   // Deep clones options, ensures no mutation of input (deep necessary because source may contain arrays)
   var clean_options = JSON.parse(JSON.stringify(options));
 
-  clean_options.senderEmailAddress = clean_options.senderEmailAddress || process.env.SENDER_EMAIL_ADDRESS
+  clean_options.senderEmailAddress = clean_options.senderEmailAddress || process.env.SENDER_EMAIL_ADDRESS;
   clean_options.toAddresses = clean_options.toAddresses || [];
   clean_options.ccAddresses = clean_options.ccAddresses || [];
   clean_options.bccAddresses = clean_options.bccAddresses || [];
@@ -95,10 +89,9 @@ function sendMany (options, callback, specific_service) {
   clean_options.html_body = compile_template(clean_options.templateName, 'html')(clean_options.context);
   clean_options.txt_body = compile_template(clean_options.templateName, 'txt')(clean_options.context);
 
-  Send(clean_options, callback, specific_service);
+  send(clean_options, callback);
 }
 
-// TODO Add injectedService to docblock
 /**
  * sendemail method takes a template name and person object and uses
  * AWS SES to send the desired email.
@@ -109,12 +102,9 @@ function sendMany (options, callback, specific_service) {
  * an empty string.
  * @param {Function} callback - continuation function called after
  * the email has been sent.
- * @param {String} specific_serivice - name of sending service to use
- * assuming set configuration, overriding default in the case of competing
- * service configurations (valid values are keys on SERVICE_CONFIGS object in lib/service.js).
  * @returns {undefined}
  */
-function sendemail (template_name, person, callback, specific_service) {
+function sendemail (template_name, person, callback) {
   var options = {
     templateName: template_name,
     context: person,
@@ -126,7 +116,7 @@ function sendemail (template_name, person, callback, specific_service) {
     bccAddresses: null
   };
 
-  sendMany(options, callback, specific_service);
+  sendMany(options, callback);
 }
 
 module.exports.email = sendemail;

--- a/lib/service.js
+++ b/lib/service.js
@@ -1,0 +1,144 @@
+'use strict';
+
+var AWS = require('aws-sdk');
+var mailgun = require('mailgun.js');
+
+// TODO Document
+// TODO Clean this up
+// required env is list of env vars for given service
+// export is object returned to and used in main script
+  // export.name is the service's name :)
+  // export.parameterize takes the options sanitized in sendMany and maps them to the
+  // input format the given service's sending function expects
+  // export.send is expected to be a function of signature (config object, callback)
+  // that handles using the service to send an email with the given parameters input by user and finessed by the main script
+var SERVICE_CONFIGS = {
+
+  mailgun: {
+    required_env: ['MAILGUN_API_KEY', 'MAILGUN_SENDING_DOMAIN'],
+    export: {
+      name: 'mailgun',
+      parameterize: function (clean_options) {
+
+        return {
+          bcc: clean_options.bccAddresses,
+          cc: clean_options.ccAddresses,
+          to: clean_options.toAddresses,
+          html: clean_options.html_body,
+          text: clean_options.txt_body,
+          subject: clean_options.subject,
+          from: clean_options.senderEmailAddress,
+          // TODO Doublecheck this actually works
+          'h:Reply-To': clean_options.replyToAddress
+        };
+      },
+      send: function (params, callback) {
+        var mg = mailgun.client({username: 'api', key: process.env.MAILGUN_API_KEY });
+        mg.messages.create(process.env.MAILGUN_SENDING_DOMAIN, params)
+          .then(function(message) {
+            return callback(undefined, message);
+          }) // logs response data
+          .catch(function(err) {
+            return callback(err);
+          });
+
+        }
+    }
+  },
+
+  ses: {
+    required_env: ['AWS_REGION', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'],
+    export: {
+      name: 'ses',
+      parameterize: function (clean_options) {
+
+        return {
+          Destination: {
+            /* required */
+            BccAddresses: clean_options.bccAddresses,
+            CcAddresses: clean_options.ccAddresses,
+            ToAddresses: clean_options.toAddresses
+          },
+          Message: {
+            /* required */
+            Body: {
+              /* required */
+              Html: {
+                Data: clean_options.html_body,
+                /* required */
+                Charset: clean_options.htmlCharset || clean_options.defaultCharset
+              },
+              Text: {
+                Data: clean_options.txt_body,
+                /* required */
+                Charset: clean_options.textCharset || clean_options.defaultCharset
+              }
+            },
+            Subject: {
+              /* required */
+              Data: clean_options.subject,
+              /* required */
+              Charset: clean_options.subjectCharset || clean_options.defaultCharset
+            }
+          },
+          Source: clean_options.senderEmailAddress, /* required */
+          ReplyToAddresses: [
+            clean_options.replyToAddress
+          ]
+        };
+      },
+      send: function (params, callback) {
+        var ses = new AWS.SES({ region: process.env.AWS_REGION });
+        return ses.sendEmail(params, callback);
+      }
+    }
+  }
+
+};
+
+function envVarExists (envVar) {
+  return process.env.hasOwnProperty(envVar) && process.env[envVar] !== undefined;
+}
+
+// TODO docbloc
+// If, for whatever reason, env vars are set for both SES and Mailgun,
+// we default to the last service in the list (currently SES)
+function determine_service (specific_service) {
+
+  if (specific_service) {
+
+    if (!SERVICE_CONFIGS[specific_service]) {
+      throw new Error('Invalid service specified');
+    }
+    if (!SERVICE_CONFIGS[specific_service].required_env.every(envVarExists)) {
+      throw new Error('Environment not configured for the specified service');
+    }
+    return SERVICE_CONFIGS[specific_service].export;
+  }
+
+  var determined = null;
+  for (var service in SERVICE_CONFIGS) {
+    if (SERVICE_CONFIGS[service].required_env.every(envVarExists)) {
+      // given multiple validly configured services, ends as latest in sequence of SERVICE_CONFIGS keys
+      determined = SERVICE_CONFIGS[service].export;
+    }
+  }
+
+  if (!determined) {
+      throw new Error('No sending service properly configured. Doublecheck the environment variables required for your service of choice');
+  }
+
+  return determined;
+}
+
+// TODO Need to test unset, setting process var, and overriding;
+module.exports.send = function (options, callback, specific_service) {
+  specific_service = process.env.CURRENT_SERVICE  ? process.env.CURRENT_SERVICE : specific_service;
+  var service = determine_service(specific_service);
+  return service.send(service.parameterize(options), callback);
+};
+
+// utility for checking currently configured service, or default in case
+// of multiple configurations
+module.exports.determine = determine_service;
+module.exports.service_configs = SERVICE_CONFIGS;

--- a/lib/service.js
+++ b/lib/service.js
@@ -3,15 +3,27 @@
 var AWS = require('aws-sdk');
 var mailgun = require('mailgun.js');
 
-// TODO Document
-// TODO Clean this up
-// required env is list of env vars for given service
-// export is object returned to and used in main script
-  // export.name is the service's name :)
-  // export.parameterize takes the options sanitized in sendMany and maps them to the
-  // input format the given service's sending function expects
-  // export.send is expected to be a function of signature (config object, callback)
-  // that handles using the service to send an email with the given parameters input by user and finessed by the main script
+/**
+ * Configuration for each integrated sending service.
+ * Each object contains the following:
+ * required_env — set of environment variables needed to configure the service,
+ * used to check that a service is configured properly
+ *
+ * export — interface to using a service in index once a service
+ * is determined to be validly configured. Has 2 methods:
+ *
+ *       - parameterize: maps options — user input — to properties of
+ *       an object in the format the service's API expects
+ *         @param {Object} clean_options — object containing data input
+ *         to main script by user (passed here by index/sendMany)
+ *         @returns {Object} options object in service-specific structure
+ *
+ *       - send: sends an email with the given configuration
+ *         @param {Object} params — configuration object for sending an email
+ *         @param {Function} callback - continuation function called after the
+ *         email has been sent.
+ *         @returns {Function} service library's sending method
+ */
 var SERVICE_CONFIGS = {
 
   mailgun: {
@@ -19,7 +31,7 @@ var SERVICE_CONFIGS = {
     export: {
       name: 'mailgun',
       parameterize: function (clean_options) {
-
+        /* eslint-disable quote-props */
         return {
           bcc: clean_options.bccAddresses,
           cc: clean_options.ccAddresses,
@@ -33,16 +45,19 @@ var SERVICE_CONFIGS = {
         };
       },
       send: function (params, callback) {
-        var mg = mailgun.client({username: 'api', key: process.env.MAILGUN_API_KEY });
-        mg.messages.create(process.env.MAILGUN_SENDING_DOMAIN, params)
-          .then(function(message) {
-            return callback(undefined, message);
-          }) // logs response data
-          .catch(function(err) {
+        var mg = mailgun.client({
+          username: 'api',
+          key: process.env.MAILGUN_API_KEY
+        });
+
+        return mg.messages.create(process.env.MAILGUN_SENDING_DOMAIN, params)
+          .then(function (message) {
+            return callback(null, message);
+          })
+          .catch(function (err) {
             return callback(err);
           });
-
-        }
+      }
     }
   },
 
@@ -51,7 +66,8 @@ var SERVICE_CONFIGS = {
     export: {
       name: 'ses',
       parameterize: function (clean_options) {
-
+        /* eslint-disable max-len */
+        // see: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SES.html#sendEmail-property
         return {
           Destination: {
             /* required */
@@ -89,6 +105,7 @@ var SERVICE_CONFIGS = {
       },
       send: function (params, callback) {
         var ses = new AWS.SES({ region: process.env.AWS_REGION });
+
         return ses.sendEmail(params, callback);
       }
     }
@@ -97,48 +114,54 @@ var SERVICE_CONFIGS = {
 };
 
 function envVarExists (envVar) {
-  return process.env.hasOwnProperty(envVar) && process.env[envVar] !== undefined;
+  return process.env.hasOwnProperty(envVar) && process.env[envVar];
 }
 
-// TODO docbloc
-// If, for whatever reason, env vars are set for both SES and Mailgun,
-// we default to the last service in the list (currently SES)
+/**
+ * Determines the sending service that the current request to send will use
+ * @param {String} specific_service - name of sending service to use;
+ * properly assuming set configuration, overrides default
+ * @returns {Object} interface for parameterizing and sending email send requests
+ * with the determined service
+ */
 function determine_service (specific_service) {
+  // Configures send to use service specified in environment.
+  // Accessible by end user, but useful only for testing, most likely.
+  // Basically, a cheat code :)
+  var specified = process.env.CURRENT_SERVICE ? process.env.CURRENT_SERVICE : specific_service;
+  var determined = null;
 
-  if (specific_service) {
-
-    if (!SERVICE_CONFIGS[specific_service]) {
+  if (specified) {
+    if (!SERVICE_CONFIGS[specified]) {
       throw new Error('Invalid service specified');
     }
-    if (!SERVICE_CONFIGS[specific_service].required_env.every(envVarExists)) {
+    if (!SERVICE_CONFIGS[specified].required_env.every(envVarExists)) {
       throw new Error('Environment not configured for the specified service');
     }
-    return SERVICE_CONFIGS[specific_service].export;
+
+    return SERVICE_CONFIGS[specified].export;
   }
 
-  var determined = null;
-  for (var service in SERVICE_CONFIGS) {
+  // given multiple validly configured services, ends as latest in
+  // sequence of SERVICE_CONFIGS keys
+  Object.keys(SERVICE_CONFIGS).forEach(function (service) {
     if (SERVICE_CONFIGS[service].required_env.every(envVarExists)) {
-      // given multiple validly configured services, ends as latest in sequence of SERVICE_CONFIGS keys
       determined = SERVICE_CONFIGS[service].export;
     }
-  }
+  });
 
   if (!determined) {
-      throw new Error('No sending service properly configured. Doublecheck the environment variables required for your service of choice');
+    throw new Error('No sending service properly configured.');
   }
 
   return determined;
 }
 
-// TODO Need to test unset, setting process var, and overriding;
-module.exports.send = function (options, callback, specific_service) {
-  specific_service = process.env.CURRENT_SERVICE  ? process.env.CURRENT_SERVICE : specific_service;
-  var service = determine_service(specific_service);
+module.exports.send = function (options, callback) {
+  var service = determine_service();
+
   return service.send(service.parameterize(options), callback);
 };
 
-// utility for checking currently configured service, or default in case
-// of multiple configurations
 module.exports.determine = determine_service;
 module.exports.service_configs = SERVICE_CONFIGS;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "quick": "./node_modules/tape/bin/tape ./test/*.js",
-    "test": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js",
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js | tap-spec",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/tape/bin/tape ./test/*.js && ./node_modules/.bin/istanbul check-coverage --statements 100 --functions 100 --lines 100 --branches 100",
     "lint": "node_modules/.bin/goodparts lib/"
   },
@@ -42,6 +42,7 @@
     "goodparts": "1.2.1",
     "istanbul": "^0.4.0",
     "pre-commit": "1.1.2",
+    "tap-spec": "^4.1.1",
     "tape": "^4.2.2"
   },
   "pre-commit": [
@@ -50,6 +51,7 @@
   ],
   "dependencies": {
     "aws-sdk": "^2.3.7",
-    "handlebars": "^4.0.3"
+    "handlebars": "^4.0.3",
+    "mailgun.js": "^2.0.1"
   }
 }

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -5,10 +5,15 @@ var dir = __dirname.split('/')[__dirname.split('/').length - 1];
 var file = dir + __filename.replace(__dirname, '');
 var test = require('tape');
 
+// TODO Delete this test / Or rather, switch to using CURRENT_SERVICE
+// TODO Add a test for using CURRENT_SERVICE
 // TODO Ok assumption?????
 // Assumes .env used for testing has all available services configured simultaneously
 test(file + " specify a sending service explicitly", function (t) {
   // value randomly selected, can be any valid service
+
+  // Better test
+  // Find default; Pick service name NOT the default; specify that; compare to default
   var specific_service = "mailgun";
   var determined = service.determine(specific_service);
   t.equal(determined.name, specific_service, "Service determined according to specified");
@@ -40,20 +45,25 @@ test(file + " attempt to use a valid, but unconfigured service", function (t) {
 
 test(file + " attempt to determine a service with no services configured", function (t) {
   var configs = service.service_configs;
-  Object.keys(configs).forEach(function (specific_service) {
-    unconfigure_service(specific_service);
-  });
+  for (var service_name in configs) {
+    unconfigure_service(service_name);
+  }
   try {
     service.determine();
   } catch (e) {
-    t.equal(e.message, "No sending service properly configured. Doublecheck the environment variables required for your service of choice");
+    t.equal(e.message, "No sending service properly configured.");
     t.end();
   }
 });
 
-// TODO Add docblock
+/**
+ * Removes all configuration for a specified service from the environment
+ *
+ * @param {String} specific_service — name of a sending service
+ * @returns undefined
+ */
 function unconfigure_service (specific_service) {
-  return service.service_configs[specific_service].required_env.forEach(function (envVar) {
+  service.service_configs[specific_service].required_env.forEach(function (envVar) {
     delete process.env[envVar];
   });
 }

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -1,0 +1,59 @@
+// No env set here, uses env set on index.test.js
+
+var service = require('../lib/service.js');
+var dir = __dirname.split('/')[__dirname.split('/').length - 1];
+var file = dir + __filename.replace(__dirname, '');
+var test = require('tape');
+
+// TODO Ok assumption?????
+// Assumes .env used for testing has all available services configured simultaneously
+test(file + " specify a sending service explicitly", function (t) {
+  // value randomly selected, can be any valid service
+  var specific_service = "mailgun";
+  var determined = service.determine(specific_service);
+  t.equal(determined.name, specific_service, "Service determined according to specified");
+  t.end();
+});
+
+test(file + " attempt to specify an invalid sending service", function (t) {
+  try {
+    service.determine("invalid")
+  } catch (e) {
+    t.equal(e.message, "Invalid service specified");
+    t.end();
+  }
+});
+
+test(file + " attempt to use a valid, but unconfigured service", function (t) {
+  var specific_service = "mailgun";
+  var remaining_service = "ses";
+  unconfigure_service(specific_service);
+  try {
+    service.determine(specific_service);
+  } catch (e) {
+    t.equal(e.message, "Environment not configured for the specified service");
+    var determined = service.determine(remaining_service);
+    t.equal(determined.name, remaining_service, "Remaining configured service still works");
+    t.end();
+  }
+});
+
+test(file + " attempt to determine a service with no services configured", function (t) {
+  var configs = service.service_configs;
+  Object.keys(configs).forEach(function (specific_service) {
+    unconfigure_service(specific_service);
+  });
+  try {
+    service.determine();
+  } catch (e) {
+    t.equal(e.message, "No sending service properly configured. Doublecheck the environment variables required for your service of choice");
+    t.end();
+  }
+});
+
+// TODO Add docblock
+function unconfigure_service (specific_service) {
+  return service.service_configs[specific_service].required_env.forEach(function (envVar) {
+    delete process.env[envVar];
+  });
+}


### PR DESCRIPTION
@nelsonic heyo! got sending with Mailgun working, tests passing, all linted

I still need to cleanup the README, specifically:

- the Background Reading section for Mailgun is plain inaccurate :) sorry! This in fact uses Mailgun's official library, not the 3rd party one
- I want to add a section describing how to use AWS and Mailgun (or any other non-SES mailing service, if added in the future) in the same deployment by specifying the CURRENT_SERVICE env var (basically, the way I set lib/service.js up, it tries to guess the service someone wants to use based on their env vars; in the case of multiple validly configured services, it goes with the last service alphabetically (SES); if, for example, someone was using S3, so would have AWS' standard env vars set, but Mailgun for emailing, the tool would try (and fail) to use S3 instead; CURRENT_SERVICE allows specifying the service you want to use, overriding that default behavior

but I figure I'll hold off on that final documentation cleanup until after handling whatever revisions you want here, once the code's in a place you're happy with

thanks again for letting me take this on! 🙏 